### PR TITLE
Pending scripts support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,34 +6,75 @@ const loadedScript = []
 const pendingScripts = new Map();
 let failedScript = []
 
-const scriptLoader = (...scripts) => (WrappedComponent) => {
+function noop() { }
 
-  const addCache = (entry) => {
-    if (loadedScript.indexOf(entry) < 0) {
-      loadedScript.push(entry)
-    }
-  }
-
-  const removeFailedScript = () => {
-    if (failedScript.length > 0) {
-      failedScript.forEach((script) => {
-        const node = document.querySelector(`script[src='${script}']`)
-        if (node != null) {
-          node.parentNode.removeChild(node)
+export function startLoadingScripts(scripts, onComplete = noop) {
+  // sequence load
+  const loadNewScript = (src) => {
+    if (loadedScript.indexOf(src) < 0) {
+      return taskComplete => {
+        const callbacks = pendingScripts.get(src) || [];
+        callbacks.push(taskComplete);
+        pendingScripts.set(src, callbacks);
+        if (callbacks.length === 1) {
+          return newScript(src)(err => {
+            pendingScripts.get(src).forEach(cb => cb(err, src));
+            pendingScripts.delete(src);
+          });
         }
-      })
-
-      failedScript = []
+      };
     }
   }
+  const tasks = scripts.map(src => {
+    if (Array.isArray(src)) {
+      return src.map(loadNewScript)
+    }
+    else return loadNewScript(src)
+  })
 
+  series(...tasks)((err, src) => {
+    if (err) {
+      failedScript.push(src)
+    }
+    else {
+      if (Array.isArray(src)) {
+        src.forEach(addCache)
+      }
+      else addCache(src)
+    }
+  })(err => {
+    removeFailedScript()
+    onComplete(err);
+  })
+}
+
+const addCache = (entry) => {
+  if (loadedScript.indexOf(entry) < 0) {
+    loadedScript.push(entry)
+  }
+}
+
+const removeFailedScript = () => {
+  if (failedScript.length > 0) {
+    failedScript.forEach((script) => {
+      const node = document.querySelector(`script[src='${script}']`)
+      if (node != null) {
+        node.parentNode.removeChild(node)
+      }
+    })
+
+    failedScript = []
+  }
+}
+
+const scriptLoader = (...scripts) => (WrappedComponent) => {
   class ScriptLoader extends Component {
     static propTypes = {
       onScriptLoaded: T.func
     };
 
     static defaultProps = {
-      onScriptLoaded: () => {}
+      onScriptLoaded: noop
     };
 
     constructor (props, context) {
@@ -46,42 +87,7 @@ const scriptLoader = (...scripts) => (WrappedComponent) => {
     }
 
     componentDidMount () {
-      // sequence load
-      const loadNewScript = (src) => {
-        if (loadedScript.indexOf(src) < 0) {
-          return taskComplete => {
-            const callbacks = pendingScripts.get(src) || [];
-            callbacks.push(taskComplete);
-            pendingScripts.set(src, callbacks);
-            if (callbacks.length === 1) {
-              return newScript(src)(err => {
-                pendingScripts.get(src).forEach(cb => cb(err, src));
-                pendingScripts.delete(src);
-              });
-            }
-          };
-        }
-      }
-      const tasks = scripts.map(src => {
-        if (Array.isArray(src)) {
-          return src.map(loadNewScript)
-        }
-        else return loadNewScript(src)
-      })
-
-      series(...tasks)((err, src) => {
-        if (err) {
-          failedScript.push(src)
-        }
-        else {
-          if (Array.isArray(src)) {
-            src.forEach(addCache)
-          }
-          else addCache(src)
-        }
-      })(err => {
-        removeFailedScript()
-
+      startLoadingScripts(scripts, err => {
         this.setState({
           isScriptLoaded: true,
           isScriptLoadSucceed: !err


### PR DESCRIPTION
This request is to avoid loading the same script twice if neither has finished loading yet.

It is possible to have multiple components on a page each require a script and yet not know about each other.  With the addition of the pendingScripts map, we can subscribe to an already downloading script instead of re-requesing it.

Note that this change also exports a function that allows scripts to arbitrarily fetched.  This way, we can prefetch scripts, and it will keep track of duplicates (as explained above).
