### PR TITLE
Make the wrapped component instance available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,10 +106,15 @@ const scriptLoader = (...scripts) => (WrappedComponent) => {
       this._isMounted = false;
     }
 
+    getWrappedInstance () {
+      return this.refs.wrappedInstance;
+    }
+
     render () {
       const props = {
         ...this.props,
-        ...this.state
+        ...this.state,
+        ref: 'wrappedInstance'
       }
 
       return (


### PR DESCRIPTION
This allows the user to call methods on the wrapped component using the same API as `react-redux`'s `connect`.