### PR TITLE
Refactored imports to prevent React 15.5.4 warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-async-script-loader",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A decorator for script lazy loading on react component",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-webpack": "~1.7.0",
     "mocha": "~2.4.5",
     "phantomjs-prebuilt": "~2.1.7",
+    "prop-types": "~15.5.8",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes as T } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import hoistStatics from 'hoist-non-react-statics'
 import { isDefined, newScript, series, noop } from './utils'
 
@@ -68,7 +69,7 @@ const removeFailedScript = () => {
 const scriptLoader = (...scripts) => (WrappedComponent) => {
   class ScriptLoader extends Component {
     static propTypes = {
-      onScriptLoaded: T.func
+      onScriptLoaded: PropTypes.func
     }
 
     static defaultProps = {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,4 +1,4 @@
-const ReactTestUtils = require('react-addons-test-utils')
+const ReactTestUtils = require('react-dom/test-utils')
 const React = require('react')
 const AsyncScriptLoader = require('../src').default
 


### PR DESCRIPTION
The latest version of React gives warnings if you import PropTypes from 'react' and ReactTestUtils from 'react-addons-test-utils'.

I changed the imports to prevent those warnings.

Tests pass. Should be no functionality changes.