### PR TITLE
Script source(s) as function (props => sources)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 lib
+yarn.lock
+package-lock.json

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,19 +3,21 @@ const React = require('react')
 const AsyncScriptLoader = require('../src').default
 
 class TestComponent extends React.Component {
-  render () {
-    return <div></div>
+  render() {
+    return <div />
   }
 }
 
-function renderTestComponent (deps, onScriptLoaded) {
+function renderTestComponent(deps, onScriptLoaded, extraProps = {}) {
   const MockedComponent = AsyncScriptLoader.apply(null, deps)(TestComponent)
-  const result = ReactTestUtils.renderIntoDocument(<MockedComponent onScriptLoaded={onScriptLoaded} />)
+  const result = ReactTestUtils.renderIntoDocument(
+    <MockedComponent onScriptLoaded={onScriptLoaded} {...extraProps} />
+  )
 
   return ReactTestUtils.findRenderedComponentWithType(result, TestComponent)
 }
 
-function checkScriptLoaded (getComponent, done) {
+function checkScriptLoaded(getComponent, done) {
   return _ => {
     const com = getComponent()
 
@@ -27,51 +29,79 @@ function checkScriptLoaded (getComponent, done) {
 }
 
 describe('Test this module', _ => {
-  it('[react-async-script-loader] Load external script after component mounted',
-    function (done) {
-      const deps = [ 'https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js' ]
-      const com = renderTestComponent(deps, onScriptLoaded)
+  it('[react-async-script-loader] Load external script after component mounted', function(done) {
+    const deps = [
+      'https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js'
+    ]
+    const com = renderTestComponent(deps, onScriptLoaded)
 
-      this.timeout(5000)
+    this.timeout(5000)
 
-      // check script tags
-      deps.forEach(testScript => {
-        const tag = document.querySelector(`script[src='${testScript}']`)
-        expect(tag).to.be.exist
-      })
+    // check script tags
+    deps.forEach(testScript => {
+      const tag = document.querySelector(`script[src='${testScript}']`)
+      expect(tag).to.be.exist
+    })
 
-      // check component props before loading
-      expect(com.props.isScriptLoaded).to.be.false
-      expect(com.props.isScriptLoadSucceed).to.be.false
+    // check component props before loading
+    expect(com.props.isScriptLoaded).to.be.false
+    expect(com.props.isScriptLoadSucceed).to.be.false
 
-      function onScriptLoaded () {
-        expect(com.props.isScriptLoaded).to.be.true
-        expect(com.props.isScriptLoadSucceed).to.be.true
+    function onScriptLoaded() {
+      expect(com.props.isScriptLoaded).to.be.true
+      expect(com.props.isScriptLoadSucceed).to.be.true
 
-        done()
-      }
+      done()
     }
-  )
+  })
 
-  it('[react-async-script-loader] No redundant script tag will be appended',
-    function (done) {
-      const deps = [ '//cdn.bootcss.com/jquery/2.1.1/jquery.min.js' ]
-      const com0 = renderTestComponent(deps, checkScriptLoaded(_ => com0, checkAllDone))
-      const com1 = renderTestComponent(deps, checkScriptLoaded(_ => com1, checkAllDone))
-      let count = 0
+  it('[react-async-script-loader] No redundant script tag will be appended', function(done) {
+    const deps = ['//cdn.bootcss.com/jquery/2.1.1/jquery.min.js']
+    const com0 = renderTestComponent(
+      deps,
+      checkScriptLoaded(_ => com0, checkAllDone)
+    )
+    const com1 = renderTestComponent(
+      deps,
+      checkScriptLoaded(_ => com1, checkAllDone)
+    )
+    let count = 0
 
-      this.timeout(5000)
+    this.timeout(5000)
 
-      // check script tags
-      deps.forEach(testScript => {
-        const tags = document.querySelectorAll(`script[src='${testScript}']`)
-        expect(tags.length).to.equal(1)
-      })
+    // check script tags
+    deps.forEach(testScript => {
+      const tags = document.querySelectorAll(`script[src='${testScript}']`)
+      expect(tags.length).to.equal(1)
+    })
 
-      function checkAllDone () {
-        count ++
-        if (count == 2) done()
-      }
+    function checkAllDone() {
+      count++
+      if (count == 2) done()
     }
-  )
+  })
+
+  it('[react-async-script-loader] Accepts a function that maps props to script sources', function(done) {
+    const scriptMapper = [
+      props => {
+        return [
+          'https://ajax.googleapis.com/ajax/libs/jquery/' +
+            props.version +
+            '/jquery.min.js'
+        ]
+      }
+    ]
+    this.timeout(5000)
+    function onScriptLoaded() {
+      const tag = document.querySelector(
+        `script[src='https://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js']`
+      )
+      expect(tag).to.exist
+      done()
+    }
+    let comWithMapper
+    comWithMapper = renderTestComponent(scriptMapper, onScriptLoaded, {
+      version: '2.0.0'
+    })
+  })
 })


### PR DESCRIPTION
Adds feature #29 

Much like connect from Redux, if sources is a function then call that function with the decorated 
component props to generate the final script sources to load.

Pull request includes automatic Prettier code formatting (sorry about that not intended), a new test to verify the functionality and the simple change to the container to calculate the scripts to load in the constructor.
