### PR TITLE
Promisify the method startLoadingScripts

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,8 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'tests.webpack.js'
+      'tests.webpack.js',
+      './node_modules/es6-promise/dist/es6-promise.js'
     ],
 
     // list of files to exclude

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
     "chai": "~3.5.0",
+    "es6-promise": "^4.2.4",
     "eslint": "^1.9.0",
     "karma": "~0.13.22",
     "karma-chai": "~0.1.0",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,7 @@
 const ReactTestUtils = require('react-dom/test-utils')
 const React = require('react')
 const AsyncScriptLoader = require('../src').default
+require('es6-promise').polyfill();
 
 class TestComponent extends React.Component {
   render () {


### PR DESCRIPTION
It's cool to use this method alone, as part of chain or with [react-loadable](https://github.com/jamiebuilds/react-loadable), like that
```javascript
Loadable.Map({
  loader: {
    Map: () => import('./Map'),
    GoogleMapApi: () => startLoadingScripts('https://maps.googleapis.com/maps/api'),
  },
  render(loaded, props) {
    let Map = loaded.Map.default;
    let GoogleMapApi = GoogleMapApi;
    return <Map {...props}/>;
  },
});
```
